### PR TITLE
Assert result of obj2 instead of obj1 in refactor-2 test 6

### DIFF
--- a/setters/refactor-2.js
+++ b/setters/refactor-2.js
@@ -41,5 +41,5 @@ obj2.modulo = 6;
 const test5 = JSON.stringify(obj1.mods) === __;
 console.assert(test5, 'Test 5');
 
-const test6 = JSON.stringify(obj1.mods) === __;
+const test6 = JSON.stringify(obj2.mods) === __;
 console.assert(test6, 'Test 6');


### PR DESCRIPTION
Currently both test 5 and test 6 would be testing the same behavior. If this was intended feel free to close this PR.